### PR TITLE
fix(ci): skip add-to-project workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/add-to-project@v1.0.2
         with:


### PR DESCRIPTION
**Problem:**
The "Add to sosoka-ops" workflow fails on all Dependabot PRs because Dependabot doesn't have access to repository secrets (ADD_TO_PROJECT_PAT).

**Error:**
```
Input required and not supplied: github-token
```

**Solution:**
Add `if: github.actor != 'dependabot[bot]'` condition to skip the job for Dependabot PRs.

**Impact:**
- Dependabot PRs will no longer show "UNSTABLE" merge status due to this workflow failure
- The workflow still runs for all human-created PRs and issues
- Actual CI (lint, type check, tests, security scan) all pass on Dependabot PRs